### PR TITLE
Changes to support WSL 6.6+

### DIFF
--- a/Windows/wsl2.md
+++ b/Windows/wsl2.md
@@ -156,6 +156,41 @@ Or installer: https://code.visualstudio.com/download#
     > Firefox is running in WSL2!
 - Additional information on USB/IP client tools can be found [here](https://github.com/dorssel/usbipd-win/wiki/WSL-support#usbip-client-tools).
 
+## Setup and test the USB system
+
+- Install this package :
+```bash
+sudo apt install usbutils
+```
+- Then try :
+```bash
+lsusb
+```
+The desired output is :
+```bash
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+```
+
+### If you don't get any ouput
+
+In newer WSL versions, the Virtual Host Controller Interface Host Controller Driver (VHCI HCD) module isn't monolithic anymore.
+VHCI HCD is used by USB IP Device to forward USB devices from Windows to WSL.
+
+Execute this command to load the module :
+```bash
+sudo modprobe vhci-hcd
+```
+
+To ensure this step is good, try the following :
+```bash
+lsusb
+```
+It should NOT be empty anymore.
+
+Reference [THREAD](https://github.com/dorssel/usbipd-win/issues/995).
+
+
 ## Setup Git
 
 - Set your global git config (same as in Windows):
@@ -225,24 +260,6 @@ Or installer: https://code.visualstudio.com/download#
   ```
   google-chrome
   ```
-
-## IMPORTANT : Load VHCI HCD module
-
-In newer WSL versions, the Virtual Host Controller Interface Host Controller Driver (VHCI HCD) module isn't monolitic anymore.
-VHCI HCD is used by USB IP Device to forward USB devices from Windows to WSL.
-
-Execute this command to load the module :
-```powershell
-sudo modprobe vhci-hcd
-```
-
-To ensure this step is good, try the following :
-```powershell
-lsusb
-```
-It should NOT be empty
-
-Reference [THREAD](https://github.com/dorssel/usbipd-win/issues/995).
 
 # Revision History
 

--- a/Windows/wsl2.md
+++ b/Windows/wsl2.md
@@ -226,6 +226,24 @@ Or installer: https://code.visualstudio.com/download#
   google-chrome
   ```
 
+## IMPORTANT : Load VHCI HCD module
+
+In newer WSL versions, the Virtual Host Controller Interface Host Controller Driver (VHCI HCD) module isn't monolitic anymore.
+VHCI HCD is used by USB IP Device to forward USB devices from Windows to WSL.
+
+Execute this command to load the module :
+```powershell
+sudo modprobe vhci-hcd
+```
+
+To ensure this step is good, try the following :
+```powershell
+lsusb
+```
+It should NOT be empty
+
+Reference [THREAD](https://github.com/dorssel/usbipd-win/issues/995).
+
 # Revision History
 
 ## 2023-06-25
@@ -284,3 +302,8 @@ Or installer: https://code.visualstudio.com/download#
 - Reduce line length to 80 where possible
 - git config init branch to main
 - Add note about Bluetooth in WSL2
+
+## 2026-02-26
+ 
+- Author: Gabriel Tetar
+- Added load VHCI HCD module step to support WSL 6.6+

--- a/Windows/wsl2.md
+++ b/Windows/wsl2.md
@@ -174,7 +174,7 @@ Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
 
 ### If you don't get any ouput
 
-In newer WSL versions, the Virtual Host Controller Interface Host Controller Driver (VHCI HCD) module isn't monolithic anymore.
+In some WSL versions, the Virtual Host Controller Interface Host Controller Driver (VHCI HCD) module isn't monolithic anymore.
 VHCI HCD is used by USB IP Device to forward USB devices from Windows to WSL.
 
 Execute this command to load the module :


### PR DESCRIPTION
I faced an issue while following the tutorial with the newer WSL 6.6

The issue is that the Linux kernel module used by USB IP Device isn't monolithic anymore. That means we need to manually load the module in order for forwarded USB devices to be correctly accessible by Linux